### PR TITLE
Fix deprecated ansible_ssh_host - update to ansible_host

### DIFF
--- a/tasks/write-configuration.yml
+++ b/tasks/write-configuration.yml
@@ -44,7 +44,7 @@
     dest: "/etc/tinc/{{ tincvpn_network }}/hosts/{{ tincvpn_nodename }}"
     mode: "0644"
   vars:
-    tincvpn_host_address: "{{ ansible_ssh_host }}"
+    tincvpn_host_address: "{{ ansible_host }}"
     tincvpn_host_public_key: "{{ public_key_generate.stdout }}"
 
 - name: download host file to coordinator


### PR DESCRIPTION
Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port.

See: https://docs.ansible.com/archive/ansible/2.4/intro_inventory.html